### PR TITLE
 Update_zeton_link

### DIFF
--- a/src/pug/sections/_events.pug
+++ b/src/pug/sections/_events.pug
@@ -37,7 +37,7 @@ section.events#events
               |
               | Jędrzej
             li 
-              a(href="https://github.com/zetonteam" target="_blank") Żeton
+              a(href="https://www.projekt-zeton.pl" target="_blank") Żeton
               | 
               | Leszek Miotk 
             li Kalendarz HS3


### PR DESCRIPTION
I prefer a link to the landing page. The link to github can be in resources.